### PR TITLE
Change some wacky syntax to be less wacky

### DIFF
--- a/src/lookup.ts
+++ b/src/lookup.ts
@@ -1,8 +1,8 @@
-import maxmind, { CityResponse } from 'maxmind';
+import maxmind, { CityResponse, Reader } from 'maxmind';
 import { Context, Callback } from 'aws-lambda';
 
 const lookupIp = async (ip: string): Promise<CityResponse | null> => {
-	const lookup = await maxmind.open<CityResponse>(`./dbs/${process.env.EDGEO_DB || 'GeoLite2-City.mmdb'}`);
+	const lookup: Reader<CityResponse> = await maxmind.open(`./dbs/${process.env.EDGEO_DB || 'GeoLite2-City.mmdb'}`);
 	const result = lookup.get(ip);
 	return result;
 };


### PR DESCRIPTION
The generic syntax on the function call looks super weird and can be a little weird to understand. Moving it to the left hand side of the assignment is IMO nicer, and clears up exactly what you're doing.

(also, Maxmind need to fix their types)